### PR TITLE
Fix crash when using it server-side

### DIFF
--- a/src/main/java/com/ezzo/fluidtranslator/ModFluidRegistry.java
+++ b/src/main/java/com/ezzo/fluidtranslator/ModFluidRegistry.java
@@ -70,7 +70,7 @@ public class ModFluidRegistry {
         Fluid forgeFluid = new Fluid(name);
         FluidRegistry.registerFluid(forgeFluid);
 
-        LanguageRegistry.instance().addStringLocalization("fluid." + name, "en_US", fluidType.getLocalizedName());
+        LanguageRegistry.instance().addStringLocalization("fluid." + name, "en_US", fluidType.getName());
 
         CustomFluidBlock block = new CustomFluidBlock(forgeFluid, Material.water, name);
         GameRegistry.registerBlock(block, CustomFluidItemBlock.class, name + "_block");


### PR DESCRIPTION
FluidRegistry used to require FluidType.LocalizedName(), which doesn't exist at the Server-side, leading to a crash when starting the server.
Just replaced it with getName() instead of the localized one.
